### PR TITLE
Allow deletion outside working dir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
 
   del = require("del");
 
-  module.exports = function(dest, destPatterns) {
+  module.exports = function(dest, destPatterns, options) {
     var srcFiles, destFiles, files, onEnd, onFile;
     files = [];
     srcFiles = [];
@@ -35,7 +35,7 @@
       var deletedFiles = _.difference(destFiles, srcFiles);
       _.each(deletedFiles, function(item, index) {
         deletedFiles[index] = dest + deletedFiles[index];
-        del.sync(deletedFiles[index]);
+        del.sync(deletedFiles[index], {force: (options ? (options.force && typeof options.force === 'boolean') : false)});
       })
 
       return this.emit("end");


### PR DESCRIPTION
Added an 'options' argument that expects an object. If a 'force' property is set, it will be passed through to del.sync to allow deletion of files outside of the current working directory.
