### PR TITLE
Modified path removal for srcFiles

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,14 +20,11 @@
     destFiles = glob.sync( destPatterns );
 
     onFile = function(file) {
-      srcFiles.push(file.path);
+      srcFiles.push(file.path.substr(file.base.length)); 
       this.push(file);
       return files.push(file);
     };
     onEnd = function() {
-      _.each(srcFiles, function(item, index) {
-        srcFiles[index] = item.substr(process.cwd().length);
-      });
       _.each(destFiles, function(item, index) {
         destFiles[index] = item.substr(dest.length);
       })


### PR DESCRIPTION
I was having issues when the current working directory value wasn't the same as the full src path to the images - this was resulting in some of the path remaining in the srcFiles array, causing the difference check to fail. I've modified the srcFiles to remove the path based of the file.base value. 

This seems to be working correctly for me, but it would be worth checking that this works as was originally intended before merging back in.
