### PR TITLE
Restore support for Node.js >=20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 20
+          - 21
           - 22
           - 23
           - 24

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "lib/index.js",
   "engines": {
-    "node": ">=22 <25"
+    "node": ">=20 <25"
   },
   "license": {
     "type": "MIT",


### PR DESCRIPTION
Node.js v20 is still supported, so there is no reason to drop support just yet.